### PR TITLE
#122 remove SUPPORT_WHITE_VALUE deprecated in 2022.9

### DIFF
--- a/custom_components/mega/light.py
+++ b/custom_components/mega/light.py
@@ -14,8 +14,7 @@ from homeassistant.components.light import (
     SUPPORT_BRIGHTNESS,
     LightEntity,
     SUPPORT_TRANSITION,
-    SUPPORT_COLOR,
-    SUPPORT_WHITE_VALUE
+    SUPPORT_COLOR
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
@@ -145,7 +144,7 @@ class MegaRGBW(LightEntity, BaseMegaEntity):
 
     @property
     def white_value(self):
-        if self.supported_features & SUPPORT_WHITE_VALUE:
+        if self.supported_features:
             return float(self.get_attribute('white_value', 0))
 
     @property
@@ -165,8 +164,7 @@ class MegaRGBW(LightEntity, BaseMegaEntity):
         return (
             SUPPORT_BRIGHTNESS |
             SUPPORT_TRANSITION |
-            SUPPORT_COLOR |
-            (SUPPORT_WHITE_VALUE if len(self.port) == 4 else 0)
+            SUPPORT_COLOR
         )
 
     def get_rgbw(self):


### PR DESCRIPTION
#122 fix error Unable to prepare setup for platform mega.light: Platform not found (cannot import name 'SUPPORT_WHITE_VALUE' from 'homeassistant.components.light'
(/usr/src/homeassistant/homeassistant/components/light/init.py)) by removing SUPPORT_WHITE_VALUE which was deprecated